### PR TITLE
Add 編集画面で使用するボタン類

### DIFF
--- a/src/components/ContentCardEditorButton.vue
+++ b/src/components/ContentCardEditorButton.vue
@@ -1,0 +1,31 @@
+<template>
+  <v-btn class="editorButton" width="48px" height="48px">
+    <v-icon :color="iconColor">{{ iconName }}</v-icon>
+  </v-btn>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'ContentCardEditorButton',
+  props: {
+    iconName: {
+      type: String,
+      required: true
+    },
+    iconColor: {
+      type: String,
+      required: false,
+      default: '#0071c2'
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.editorButton {
+  border-radius: 14px;
+  min-width: 48px !important;
+}
+</style>

--- a/src/components/ContentCardEditorButton.vue
+++ b/src/components/ContentCardEditorButton.vue
@@ -1,6 +1,6 @@
 <template>
   <v-btn class="editorButton" width="48px" height="48px">
-    <v-icon :color="iconColor">{{ iconName }}</v-icon>
+    <v-icon :color="iconColor" :size="iconSize">{{ iconName }}</v-icon>
   </v-btn>
 </template>
 
@@ -18,6 +18,11 @@ export default Vue.extend({
       type: String,
       required: false,
       default: '#0071c2'
+    },
+    iconSize: {
+      type: [String, Number],
+      required: false,
+      default: '24px'
     }
   }
 })


### PR DESCRIPTION
close #60 

## 実装内容

- ボタンの大きさは 48px × 48px で固定
- アイコンの大きさは `icon-size` で指定可能。デフォルトは `'24px'`
- アイコンの色は `icon-color` で指定可能。デフォルトは `'#0071c2'`
- アイコンの名前は `icon-name` で指定可能。必須。デフォルト値は無し。

## スクリーンショット

![image](https://user-images.githubusercontent.com/34566290/82724375-9b5fb600-9d10-11ea-885b-b95a3df493da.png)

## WIP

- `'#0071c2'` は `variables.scss` などに変数として格納したほうが良さそう。
