### PR TITLE
クラスデータ内授業データ取得の修正

### DIFF
--- a/src/layouts/classes.vue
+++ b/src/layouts/classes.vue
@@ -113,7 +113,7 @@ export default Vue.extend({
   },
   mounted(): void {
     this.loading = false
-    this.classData.displayDate = dayjs().format('YYYY-MM-DD')
+    this.classData.displayDate = dayjs().toDate()
   }
 })
 </script>

--- a/src/pages/classes/index.vue
+++ b/src/pages/classes/index.vue
@@ -1,18 +1,16 @@
 <template>
   <div class="MainPage">
-    <v-row v-if="classData.lessons[classData.displayDate]" class="DataBlock">
+    <v-row v-if="classData.getLessonsByDate" class="DataBlock">
       <v-col
-        v-for="(item, i) in classData.lessons[classData.displayDate]"
+        v-for="(item, i) in classData.getLessonsByDate"
         :key="i"
         cols="12"
         md="6"
       >
-        <!-- @todo データ構造にあわせる -->
-        <StudyCard
-          :schooltime="i + 1"
-          :realtime="item.startTime"
-          :content="item.content"
-          :subject="item.subject"
+        <ContentCard
+          :content="formatDate(item.startTime)"
+          :title="item.content"
+          :subjects="[{ name: item.subject }]"
         />
       </v-col>
     </v-row>
@@ -34,7 +32,7 @@
 import Vue from 'vue'
 import dayjs from 'dayjs'
 import { vxm } from '@/store'
-import StudyCard from '@/components/StudyCard.vue'
+import ContentCard from '@/components/ContentCard.vue'
 
 type Data = {
   classData: typeof vxm.classData
@@ -46,7 +44,7 @@ type Computed = {
 }
 
 export default Vue.extend<Data, unknown, Computed, unknown>({
-  components: { StudyCard },
+  components: { ContentCard },
   layout: 'classes',
   data() {
     return {
@@ -55,10 +53,18 @@ export default Vue.extend<Data, unknown, Computed, unknown>({
   },
   computed: {
     isToday() {
-      return this.classData.displayDate === dayjs().format('YYYY-MM-DD')
+      return (
+        dayjs(this.classData.displayDate).format('YYYY-MM-DD') ===
+        dayjs().format('YYYY-MM-DD')
+      )
     },
     dateTitle() {
       return dayjs(this.classData.displayDate).format('M/D')
+    }
+  },
+  methods: {
+    formatDate(date: Date): string {
+      return dayjs(date).format('HH:MM')
     }
   }
 })

--- a/src/pages/classes/index.vue
+++ b/src/pages/classes/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="MainPage">
-    <v-row v-if="classData.getLessonsByDate" class="DataBlock">
+    <v-row v-if="classData.getLessonsByDisplayDate" class="DataBlock">
       <v-col
-        v-for="(item, i) in classData.getLessonsByDate"
+        v-for="(item, i) in classData.getLessonsByDisplayDate"
         :key="i"
         cols="12"
         md="6"

--- a/src/pages/classes/index.vue
+++ b/src/pages/classes/index.vue
@@ -8,7 +8,7 @@
         md="6"
       >
         <ContentCard
-          :content="formatDate(item.startTime)"
+          :description="formatDate(item.startTime)"
           :title="item.content"
           :subjects="[{ name: item.subject }]"
         />

--- a/src/store/modules/classData.ts
+++ b/src/store/modules/classData.ts
@@ -1,6 +1,7 @@
 import { createModule, mutation, action } from 'vuex-class-component'
 import dayjs from 'dayjs'
 import firebase from '@/plugins/firebase'
+import Timestamp = firebase.firestore.Timestamp
 
 const VuexModule = createModule({
   namespaced: 'classData',
@@ -10,9 +11,8 @@ const VuexModule = createModule({
 
 type ClassId = string
 type ClassName = string
-type SchoolName = string
-type Lessons = { [key: string]: Lesson }
-type DisplayDate = string
+type Lessons = Lesson[]
+type DisplayDate = Date
 
 interface Lesson {
   subject: string
@@ -21,16 +21,21 @@ interface Lesson {
   endTime: Date
 }
 
+interface RawLesson {
+  subject: string
+  content: string
+  startTime: Timestamp
+  endTime: Timestamp
+}
+
 interface RawClassData {
-  schoolName: ClassName
-  className: SchoolName
+  className: ClassName
   lessons: Lessons
 }
 
 interface ClassData {
   classId: ClassId
-  schoolName: ClassName
-  className: SchoolName
+  className: ClassName
   lessons: Lessons
   displayDate: DisplayDate
 }
@@ -38,12 +43,37 @@ interface ClassData {
 export class ClassDataStore extends VuexModule implements ClassData {
   classId: ClassId = ''
   className: ClassName = ''
-  schoolName: SchoolName = ''
-  lessons: Lessons = {}
-  displayDate: DisplayDate = ''
+  lessons: Lessons = []
+  displayDate: DisplayDate = new Date()
+
+  public get getLessonsByDate(): Lessons {
+    const dateStart = new Date(
+      this.displayDate.getFullYear(),
+      this.displayDate.getMonth(),
+      this.displayDate.getDay(),
+      0,
+      0,
+      0
+    )
+    const dateEnd = new Date(
+      this.displayDate.getFullYear(),
+      this.displayDate.getMonth(),
+      this.displayDate.getDay(),
+      23,
+      59,
+      59
+    )
+    const lessonsByDate: Lessons = []
+    this.lessons.forEach(value => {
+      const sec = value.startTime.getTime()
+      if (dateStart.getTime() <= sec && dateEnd.getTime() >= sec)
+        lessonsByDate.push(value)
+    })
+    return lessonsByDate
+  }
 
   public get isLoaded(): boolean {
-    return !!this.schoolName && !!this.className
+    return !!this.className
   }
 
   @mutation
@@ -52,13 +82,8 @@ export class ClassDataStore extends VuexModule implements ClassData {
   }
 
   @mutation
-  private setDataFromRawClassData({
-    className,
-    schoolName,
-    lessons
-  }: RawClassData) {
+  private setDataFromRawClassData({ className, lessons }: RawClassData) {
     this.className = className
-    this.schoolName = schoolName
     this.lessons = lessons
   }
 
@@ -66,19 +91,51 @@ export class ClassDataStore extends VuexModule implements ClassData {
   public nextDate() {
     this.displayDate = dayjs(this.displayDate)
       .add(1, 'd')
-      .format('YYYY-MM-DD')
+      .toDate()
   }
 
   @mutation
   public prevDate() {
     this.displayDate = dayjs(this.displayDate)
       .subtract(1, 'd')
-      .format('YYYY-MM-DD')
+      .toDate()
+  }
+
+  @mutation
+  public setDate(date: Date) {
+    this.displayDate = date
   }
 
   @action
   public async loadClassData(classId: ClassId) {
-    return firebase
+    let className = ''
+    const lessons: Lesson[] = []
+    await firebase
+      .firestore()
+      .collection('classData')
+      .doc(classId)
+      .collection('Lessons')
+      .get()
+      .then(QuerySnapshot => {
+        QuerySnapshot.forEach(function(doc) {
+          const data = doc.data() as RawLesson
+          const reformatData = {
+            subject: data.subject,
+            content: data.content,
+            startTime: data.startTime.toDate(),
+            endTime: new Date()
+          }
+          lessons.push(reformatData)
+        })
+      })
+      .catch(() => {
+        return Promise.reject(new Error('クラスIDが間違っています'))
+      })
+    lessons.sort((a, b) => {
+      return a.startTime > b.startTime ? 1 : -1
+    })
+
+    await firebase
       .firestore()
       .collection('classData')
       .doc(classId)
@@ -87,13 +144,13 @@ export class ClassDataStore extends VuexModule implements ClassData {
         if (!snapshot.exists)
           return Promise.reject(new Error('クラスIDが間違っています'))
 
-        const { className, schoolName, lessons } = snapshot.data() as ClassData
-        this.setClassId(classId)
-        this.setDataFromRawClassData({
-          className,
-          schoolName,
-          lessons
-        })
+        const data = snapshot.data() as ClassData
+        className = data.className
       })
+    this.setClassId(classId)
+    this.setDataFromRawClassData({
+      className,
+      lessons
+    })
   }
 }

--- a/src/store/modules/classData.ts
+++ b/src/store/modules/classData.ts
@@ -46,7 +46,7 @@ export class ClassDataStore extends VuexModule implements ClassData {
   lessons: Lessons = []
   displayDate: DisplayDate = new Date()
 
-  public get getLessonsByDate(): Lessons {
+  public get getLessonsByDisplayDate(): Lessons {
     const dateStart = new Date(
       this.displayDate.getFullYear(),
       this.displayDate.getMonth(),


### PR DESCRIPTION
close #92 
close #52 
DisplayDateに関しては複数コンポーネントに横断して利用するため残しています。
getLessonsByDisplayDateはDisplayDateに一致するもののみを時間順に取得します。