### PR TITLE
v-overlayの表示切替をvalueに修正

### DIFF
--- a/src/layouts/classes.vue
+++ b/src/layouts/classes.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <v-overlay v-if="loading" color="#0071C2" opacity="1" z-index="9999">
+    <v-overlay :value="loading" color="#0071C2" opacity="1" z-index="9999">
       <div class="loader">
         Loading
       </div>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,11 +1,6 @@
 <template>
   <v-app>
-    <v-overlay
-      v-if="loading"
-      color="$color-base-color-01"
-      opacity="1"
-      z-index="9999"
-    >
+    <v-overlay :value="loading" color="#0071C2" opacity="1" z-index="9999">
       <div class="loader">
         Loading
       </div>

--- a/src/layouts/protected.vue
+++ b/src/layouts/protected.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <v-overlay v-if="loading" color="#0071C2" opacity="1" z-index="9999">
+    <v-overlay :value="loading" color="#0071C2" opacity="1" z-index="9999">
       <div class="loader">
         Loading
       </div>


### PR DESCRIPTION
close #111 

- `v-overlay` の表示切替を `v-if` から `value` に修正しました。
- sassの変数が入っていたcolor属性に色の値を直接指定しました。

表示に変化はありません。
[![Image from Gyazo](https://i.gyazo.com/270dbc7e31d6cd2a4ae2c20dc9fc4c95.gif)](https://gyazo.com/270dbc7e31d6cd2a4ae2c20dc9fc4c95)