### PR TITLE
汎用（モーダル）ダイアログ componentを作成

### DIFF
--- a/src/components/ActionButton.vue
+++ b/src/components/ActionButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <button :class="`ActionButton ActionButton-${theme}`" @click="onClick">
+  <button :class="`ActionButton ActionButton-${theme}`" @click="$emit('click')">
     <span>{{ text }}</span>
   </button>
 </template>
@@ -16,10 +16,6 @@ export default class ActionButton extends Vue {
 
   @Prop({ default: '' })
   text!: string | undefined
-
-  onClick(): void {
-    this.$router.push('/')
-  }
 }
 </script>
 

--- a/src/components/BaseDialog.vue
+++ b/src/components/BaseDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog :value="value" @input="$emit('input', $event)">
+  <v-dialog :value="value" :persistent="modal" @input="$emit('input', $event)">
     <v-card class="DialogCard">
       <v-card-title class="DialogCardTitle">
         <v-icon class="DialogCardTitleIcon" size="48">{{ iconName }}</v-icon>
@@ -45,6 +45,7 @@ type Props = {
   hideDefaultCancelButton: boolean
   defaultCancelButtonLabel: string
   actions: DialogAction[]
+  modal: boolean
   value: boolean
 }
 
@@ -73,6 +74,11 @@ export default Vue.extend<unknown, Methods, unknown, Props>({
     actions: {
       type: Array as () => DialogAction[],
       required: true
+    },
+    modal: {
+      type: Boolean,
+      required: false,
+      default: false
     },
     value: {
       type: Boolean,

--- a/src/components/BaseDialog.vue
+++ b/src/components/BaseDialog.vue
@@ -53,7 +53,7 @@ type Methods = {
 }
 
 export default Vue.extend<unknown, Methods, unknown, Props>({
-  name: 'BaseModalDialog',
+  name: 'BaseDialog',
   components: { ActionButton },
   props: {
     iconName: {

--- a/src/components/BaseModalDialog.vue
+++ b/src/components/BaseModalDialog.vue
@@ -1,0 +1,109 @@
+<template>
+  <v-dialog :value="value" @input="$emit('input', $event)">
+    <v-card class="DialogCard">
+      <v-card-title class="DialogCardTitle">
+        <v-icon class="DialogCardTitleIcon" size="48">{{ iconName }}</v-icon>
+        <slot class="DialogCardTitleText" name="title" />
+      </v-card-title>
+      <v-container class="DialogCardContentContainer">
+        <slot />
+      </v-container>
+      <v-card-actions class="DialogCardButtons px-4">
+        <action-button
+          v-for="(action, i) in actions"
+          :key="i"
+          class="my-3"
+          :text="action.buttonLabel"
+          @click="doDialogAction(i)"
+        />
+        <action-button
+          v-if="!hideDefaultCancelButton"
+          :text="defaultCancelButtonLabel"
+          theme="border"
+          class="my-3"
+          @click="$emit('input', false)"
+        />
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import ActionButton from '@/components/ActionButton.vue'
+
+export type DialogAction = {
+  buttonLabel: string
+  /**
+   * ボタン押下時に実行する処理。実行後に BaseModalDialog を閉じないようにするには true を返す。
+   */
+  action: () => boolean | void
+}
+
+type Props = {
+  iconName: string
+  hideDefaultCancelButton: boolean
+  defaultCancelButtonLabel: string
+  actions: DialogAction[]
+  value: boolean
+}
+
+type Methods = {
+  doDialogAction(buttonIndex: number): void
+}
+
+export default Vue.extend<unknown, Methods, unknown, Props>({
+  name: 'SimpleModalDialog',
+  components: { ActionButton },
+  props: {
+    iconName: {
+      type: String,
+      required: true
+    },
+    hideDefaultCancelButton: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    defaultCancelButtonLabel: {
+      type: String,
+      required: false,
+      default: 'キャンセル'
+    },
+    actions: {
+      type: Array as () => DialogAction[],
+      required: true
+    },
+    value: {
+      type: Boolean,
+      default: false
+    }
+  },
+  methods: {
+    doDialogAction(index) {
+      if (!this.actions[index].action()) {
+        this.$emit('input', false)
+      }
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.v-dialog {
+  .DialogCard {
+    border-radius: 14px;
+
+    &Title,
+    &Buttons {
+      flex-direction: column;
+    }
+
+    &Title,
+    &TitleIcon {
+      color: $color-base-color-01;
+      font-size: 16px;
+    }
+  }
+}
+</style>

--- a/src/components/BaseModalDialog.vue
+++ b/src/components/BaseModalDialog.vue
@@ -53,7 +53,7 @@ type Methods = {
 }
 
 export default Vue.extend<unknown, Methods, unknown, Props>({
-  name: 'SimpleModalDialog',
+  name: 'BaseModalDialog',
   components: { ActionButton },
   props: {
     iconName: {


### PR DESCRIPTION
close #118 

`ActionButton.vue` を一部書き換えているのでコンフリクトの可能性あり

## 使用方法の例
```vue
<template>
  ...
  <v-btn @click.stop="showDuplicateModalWindow = true">
    click
  </v-btn>
  <base-modal-dialog
    v-model="showDuplicateModalWindow"
    icon-name="mdi-email"
    :actions="actions"
  >
    <template v-slot:title>
      タイトル
    </template>
    <template v-slot:default>
      asdasdasad
    </template>
  </base-modal-dialog>
  ...
</template>

<script lang="ts">
import Vue from 'vue'
import BaseModalDialog, { DialogAction } from '@/components/BaseModalDialog.vue'

type DataType = {
  showDuplicateModalWindow: boolean
  actions: DialogAction[]
}

export default Vue.extend({
  components: { BaseModalDialog },
  data(): DataType {
    return {
      showDuplicateModalWindow: false,
      actions: [
        { buttonLabel: 'a', action: () => true },
        { buttonLabel: 'bsdb', action: () => {} }
      ]
    }
  },
  ...
})
</script>
```

### スクリーンショット
![image](https://user-images.githubusercontent.com/34566290/84295513-a4141100-ab85-11ea-8cb9-cae722a51dec.png)
![image](https://user-images.githubusercontent.com/34566290/84295531-a8d8c500-ab85-11ea-9b7a-8572e3ef710b.png)
