### PR TITLE
CalendarBarの「現在日」はVuex Storeが保持する

### DIFF
--- a/src/components/CalendarBar.vue
+++ b/src/components/CalendarBar.vue
@@ -93,6 +93,9 @@ class DateListWindowImpl implements DateListWindow {
       this.startWeekOn,
       vxm.classData.displayDate
     )
+    vxm.classData.$watch('displayDate', () => {
+      this.list = this.generateDateList()
+    })
   }
 
   nextDay(): DateListWindow {
@@ -124,7 +127,6 @@ class DateListWindowImpl implements DateListWindow {
       this.view,
       isValid(date) ? date : new Date()
     )
-    this.list = this.generateDateList()
     return this
   }
 

--- a/src/layouts/classes.vue
+++ b/src/layouts/classes.vue
@@ -13,7 +13,7 @@
       </v-btn>
       <template v-slot:extension>
         <div class="header-calender">
-          <CalendarBar v-model="date" />
+          <CalendarBar />
         </div>
       </template>
     </v-app-bar>
@@ -29,11 +29,9 @@
 import Vue from 'vue'
 import HeaderLogo from '@/assets/svgs/header_logo.svg'
 import CalendarBar from '@/components/CalendarBar.vue'
-import { vxm } from '@/store'
 
 type LocalData = {
   loading: boolean
-  date: Date
 }
 
 export default Vue.extend({
@@ -44,13 +42,7 @@ export default Vue.extend({
   },
   data(): LocalData {
     return {
-      loading: true,
-      date: new Date()
-    }
-  },
-  watch: {
-    date(value) {
-      vxm.classData.setDate(value)
+      loading: true
     }
   },
   mounted(): void {


### PR DESCRIPTION
close #126 

下のアニメーションGIFの通り、CalendarBarを直接タップしても、プログラム的にVuex Storeのデータを書き換えても期待通りに描画できるようになった。（週をまたいでも正常に各日のボタンが再生成される）
（PREVDATEやその直下のデータ表示はテスト用の物）
これで日付ピッカーを追加したときに直接Vuex Storeの現在日の値を変更するだけで日付表示・時間割表示の全てを変更できるようになった。

![studyathome_202006110324](https://user-images.githubusercontent.com/34566290/84304436-7930b980-ab93-11ea-933e-55aebe86f7f9.gif)

これによりCalendarBar.vue内でcurrentDateを保持する必要がなくなり、v-modelを使う必要もなくなったので該当箇所のコードも除去
