### PR TITLE
データバインディングを整理

### DIFF
--- a/src/components/AddButton.vue
+++ b/src/components/AddButton.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
   },
   methods: {
     onClick(): void {
-      this.$emit('addButtonClicked')
+      this.$emit('clickAddButton')
     }
   }
 })

--- a/src/components/AddButton.vue
+++ b/src/components/AddButton.vue
@@ -4,7 +4,7 @@
     :color="buttonColor"
     :width="buttonSize"
     :height="buttonSize"
-    @click="onClick"
+    @click="$emit('clickAddButton')"
   >
     <v-icon :size="iconSize" :color="iconColor">{{ iconName }}</v-icon>
   </v-btn>
@@ -40,11 +40,6 @@ export default Vue.extend({
       type: [String, Number],
       required: false,
       default: '40'
-    }
-  },
-  methods: {
-    onClick(): void {
-      this.$emit('clickAddButton')
     }
   }
 })

--- a/src/components/BottomSheetLayer.vue
+++ b/src/components/BottomSheetLayer.vue
@@ -1,10 +1,11 @@
 <template>
   <v-bottom-sheet
-    v-model="layer"
+    :value="value"
     persistent
     scrollable
     no-click-animation
     :fullscreen="fullscreen"
+    @input="$emit('input', $event)"
   >
     <v-card class="Layer">
       <v-card-title class="Layer-CardElements Layer-CardTitle">
@@ -32,13 +33,9 @@
 <script lang="ts">
 import Vue from 'vue'
 
-type DataType = {
-  layer: boolean
-}
-
 export default Vue.extend({
   props: {
-    expanded: {
+    value: {
       type: Boolean,
       required: false,
       default: true
@@ -55,16 +52,6 @@ export default Vue.extend({
       type: Boolean,
       required: false,
       default: false
-    }
-  },
-  data(): DataType {
-    return {
-      layer: this.expanded
-    }
-  },
-  watch: {
-    expanded(newValue) {
-      this.layer = newValue
     }
   }
 })

--- a/src/components/EditingScreen.vue
+++ b/src/components/EditingScreen.vue
@@ -1,11 +1,5 @@
 <template>
-  <v-bottom-sheet
-    :value="expanded"
-    no-click-animation
-    persistent
-    scrollable
-    @input="$emit('update:expanded', $event)"
-  >
+  <v-bottom-sheet :value="expanded" no-click-animation persistent scrollable>
     <v-card class="EditingScreen">
       <v-card-title class="EditingScreen-CardElements">
         <v-container class="EditingScreen-Container">

--- a/src/components/EditingScreen.vue
+++ b/src/components/EditingScreen.vue
@@ -1,5 +1,11 @@
 <template>
-  <v-bottom-sheet v-model="screen" no-click-animation persistent scrollable>
+  <v-bottom-sheet
+    :value="expanded"
+    no-click-animation
+    persistent
+    scrollable
+    @input="$emit('update:expanded', $event)"
+  >
     <v-card class="EditingScreen">
       <v-card-title class="EditingScreen-CardElements">
         <v-container class="EditingScreen-Container">
@@ -100,7 +106,6 @@ type FourthPageDataType = {
 }
 
 type DataType = {
-  screen: boolean
   page: number
   error: boolean
   lessonId: string
@@ -158,7 +163,6 @@ export default Vue.extend({
   },
   data(): DataType {
     return {
-      screen: this.expanded,
       page: 1,
       error: false,
       isHidden: this.value.isHidden,
@@ -199,9 +203,6 @@ export default Vue.extend({
     }
   },
   watch: {
-    expanded(newValue) {
-      this.screen = newValue
-    },
     value(value) {
       this.isHidden = value.isHidden
       this.lessonId = value.lessonId

--- a/src/components/EditorField.vue
+++ b/src/components/EditorField.vue
@@ -3,11 +3,12 @@
     <span v-if="title" class="EditorField-Title">{{ title }}</span>
     <div class="EditorField-Form">
       <editor-input-field
-        v-model="modelValue"
+        :value="value"
         :label="label"
         :placeholder="placeholder"
         :transparent="transparent"
         :readonly="readonly"
+        @input="$emit('input', $event)"
       />
       <content-card-editor-button
         v-if="iconName"
@@ -23,10 +24,6 @@
 import Vue from 'vue'
 import EditorInputField from '@/components/EditorInputField.vue'
 import ContentCardEditorButton from '@/components/ContentCardEditorButton.vue'
-
-type DataType = {
-  modelValue: string
-}
 
 export default Vue.extend({
   components: { EditorInputField, ContentCardEditorButton },
@@ -65,19 +62,6 @@ export default Vue.extend({
       type: String,
       required: false,
       default: ''
-    }
-  },
-  data(): DataType {
-    return {
-      modelValue: this.value
-    }
-  },
-  watch: {
-    modelValue(value) {
-      this.$emit('input', value)
-    },
-    value(value) {
-      this.modelValue = value
     }
   }
 })

--- a/src/components/EditorInputField.vue
+++ b/src/components/EditorInputField.vue
@@ -1,6 +1,6 @@
 <template>
   <v-text-field
-    v-model="modelValue"
+    :value="value"
     :color="transparent ? 'white' : '#424242'"
     type="text"
     :hint="hint"
@@ -11,14 +11,13 @@
     class="elevation-0"
     solo
     flat
+    @input="$emit('input', $event)"
   />
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-type DataType = {
-  modelValue: string
-}
+
 export default Vue.extend({
   name: 'InputField',
   props: {
@@ -61,19 +60,6 @@ export default Vue.extend({
       type: String,
       required: true,
       default: ''
-    }
-  },
-  data(): DataType {
-    return {
-      modelValue: this.value
-    }
-  },
-  watch: {
-    modelValue(value) {
-      this.$emit('input', value)
-    },
-    value(value) {
-      this.modelValue = value
     }
   }
 })

--- a/src/components/EditorTextarea.vue
+++ b/src/components/EditorTextarea.vue
@@ -2,7 +2,7 @@
   <div>
     <span v-if="title" class="EditorTextarea-Title">{{ title }}</span>
     <v-textarea
-      v-model="modelValue"
+      :value="value"
       :hint="hint"
       :label="label"
       :placeholder="placeholder"
@@ -10,16 +10,13 @@
       class="elevation-0"
       solo
       flat
+      @input="$emit('input', $event)"
     />
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-
-type DataType = {
-  modelValue: string
-}
 
 export default Vue.extend({
   props: {
@@ -47,19 +44,6 @@ export default Vue.extend({
       type: String,
       required: false,
       default: ''
-    }
-  },
-  data(): DataType {
-    return {
-      modelValue: this.value
-    }
-  },
-  watch: {
-    modelValue(value) {
-      this.$emit('input', value)
-    },
-    value(value) {
-      this.modelValue = value
     }
   }
 })

--- a/src/components/InputField.vue
+++ b/src/components/InputField.vue
@@ -1,7 +1,7 @@
 <template>
   <v-text-field
     v-if="type === 'password'"
-    v-model="value"
+    :value="value"
     :color="textFieldColor"
     :type="show ? 'text' : 'password'"
     :hint="hint"
@@ -12,6 +12,7 @@
     solo
     flat
     outlined
+    @input="$emit('input', $event)"
   >
     <template v-slot:prepend-inner>
       <v-icon :color="prependIconColor">{{ prependIcon }}</v-icon>
@@ -26,7 +27,7 @@
   </v-text-field>
   <v-text-field
     v-else-if="type === 'email'"
-    v-model="value"
+    :value="value"
     :color="textFieldColor"
     type="text"
     :hint="hint"
@@ -37,6 +38,7 @@
     solo
     flat
     outlined
+    @input="$emit('input', $event)"
   >
     <template v-slot:prepend-inner>
       <v-icon :color="prependIconColor">{{ prependIcon }}</v-icon>
@@ -44,7 +46,7 @@
   </v-text-field>
   <v-text-field
     v-else-if="type === 'classId'"
-    v-model="value"
+    :value="value"
     :color="textFieldColor"
     type="text"
     :hint="hint"
@@ -55,6 +57,7 @@
     solo
     flat
     outlined
+    @input="$emit('input', $event)"
   >
     <template v-slot:prepend-inner>
       <v-icon :color="prependIconColor">{{ prependIcon }}</v-icon>
@@ -62,7 +65,7 @@
   </v-text-field>
   <v-text-field
     v-else
-    v-model="value"
+    :value="value"
     :color="textFieldColor"
     type="text"
     :hint="hint"
@@ -73,6 +76,7 @@
     solo
     flat
     outlined
+    @input="$emit('input', $event)"
   >
     <template v-slot:prepend-inner>
       <v-icon :color="prependIconColor">{{ prependIcon }}</v-icon>
@@ -83,12 +87,15 @@
 <script lang="ts">
 import Vue from 'vue'
 type DataType = {
-  value: string
   show: boolean
 }
 export default Vue.extend({
   name: 'InputField',
   props: {
+    value: {
+      type: String,
+      default: ''
+    },
     type: {
       type: String,
       required: false,
@@ -122,8 +129,7 @@ export default Vue.extend({
   },
   data(): DataType {
     return {
-      show: false,
-      value: ''
+      show: false
     }
   },
   computed: {
@@ -181,11 +187,6 @@ export default Vue.extend({
         if (!this.value) return 'mdi-alert-circle'
       }
       return 'mdi-check-circle'
-    }
-  },
-  watch: {
-    value(value) {
-      this.$emit('input', value)
     }
   }
 })

--- a/src/components/SimpleBottomSheet.vue
+++ b/src/components/SimpleBottomSheet.vue
@@ -1,6 +1,6 @@
 <template>
   <v-bottom-sheet
-    v-model="sheet"
+    :value="expanded"
     class="sheet"
     persistent
     scrollable
@@ -15,7 +15,7 @@
             <v-col class="col message">{{ message }}</v-col>
             <v-col cols="2">
               <span class="add-button">
-                <add-button @addButtonClicked="addButtonClicked" />
+                <add-button @addButtonClicked="$emit('addButtonClicked')" />
               </span>
             </v-col>
           </v-row>
@@ -42,22 +42,6 @@ export default Vue.extend({
       type: Boolean,
       required: false,
       default: true
-    }
-  },
-  data() {
-    return {
-      sheet: this.expanded
-    }
-  },
-  watch: {
-    expanded(newValue) {
-      this.sheet = newValue
-    }
-  },
-  methods: {
-    addButtonClicked() {
-      this.sheet = !this.sheet
-      this.$emit('addButtonClicked', this.sheet)
     }
   }
 })

--- a/src/components/SimpleBottomSheet.vue
+++ b/src/components/SimpleBottomSheet.vue
@@ -15,7 +15,7 @@
             <v-col class="col message">{{ message }}</v-col>
             <v-col cols="2">
               <span class="add-button">
-                <add-button @addButtonClicked="$emit('addButtonClicked')" />
+                <add-button @clickAddButton="$emit('clickAddButton')" />
               </span>
             </v-col>
           </v-row>

--- a/src/layouts/classes.vue
+++ b/src/layouts/classes.vue
@@ -13,7 +13,7 @@
       </v-btn>
       <template v-slot:extension>
         <div class="header-calender">
-          <CalendarBar v-model="date" />
+          <CalendarBar v-model="app.currentDate" />
         </div>
       </template>
     </v-app-bar>
@@ -33,7 +33,7 @@ import { vxm } from '@/store'
 
 type LocalData = {
   loading: boolean
-  date: Date
+  app: typeof vxm.app
 }
 
 export default Vue.extend({
@@ -45,12 +45,7 @@ export default Vue.extend({
   data(): LocalData {
     return {
       loading: true,
-      date: new Date()
-    }
-  },
-  watch: {
-    date(value) {
-      vxm.app.setDate(value)
+      app: vxm.app
     }
   },
   mounted(): void {

--- a/src/layouts/protected.vue
+++ b/src/layouts/protected.vue
@@ -21,7 +21,7 @@
       </div>
       <template v-slot:extension>
         <div class="header-calender">
-          <CalendarBar v-model="date" />
+          <CalendarBar v-model="app.currentDate" />
         </div>
       </template>
     </v-app-bar>
@@ -41,7 +41,7 @@ import CalendarBar from '@/components/CalendarBar.vue'
 
 type LocalData = {
   loading: boolean
-  date: Date
+  app: typeof vxm.app
 }
 
 export default Vue.extend({
@@ -53,12 +53,7 @@ export default Vue.extend({
   data(): LocalData {
     return {
       loading: true,
-      date: new Date()
-    }
-  },
-  watch: {
-    date(value) {
-      vxm.app.setDate(value)
+      app: vxm.app
     }
   },
   mounted(): void {

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -28,12 +28,12 @@
     </div>
     <simple-bottom-sheet
       message="2年B組の授業を追加・編集する"
-      :expanded="isExpandedButton"
+      :expanded="!editingMode"
       @clickAddButton="onClickAddButton"
     />
     <editing-screen
       :value="editPageValue"
-      :expanded="!isExpandedButton"
+      :expanded="editingMode"
       @collapse="onCollapseEditingScreen"
     />
   </div>
@@ -51,7 +51,7 @@ import { classData } from '~/types/store/classData'
 
 type DataType = {
   classData: typeof vxm.classData
-  isExpandedButton: boolean
+  editingMode: boolean
   editPageValue: object
 }
 
@@ -65,7 +65,7 @@ export default Vue.extend({
   data(): DataType {
     return {
       classData: vxm.classData,
-      isExpandedButton: true,
+      editingMode: false,
       editPageValue: {
         isHidden: false,
         lessonId: '',
@@ -111,7 +111,7 @@ export default Vue.extend({
       this.resetEditingScreen()
     },
     toggleScreen(): void {
-      this.isExpandedButton = !this.isExpandedButton
+      this.editingMode = !this.editingMode
     },
     resetEditingScreen(): void {
       this.editPageValue = {

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -138,6 +138,7 @@ export default Vue.extend({
         }
       }
     },
+    // @todo doEdit の中身を整理する
     doEdit(value: classData.LessonWithId): void {
       const videoUrl = value.videos.length === 0 ? '' : value.videos[0].url
       const videoTitle = value.videos.length === 0 ? '' : value.videos[0].title

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -34,6 +34,7 @@
     <editing-screen
       :value="editPageValue"
       :expanded="!isExpandedButton"
+      @update:expanded="isExpandedButton = $event"
       @collapse="closeToReset"
     />
   </div>

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -104,16 +104,16 @@ export default Vue.extend({
   },
   methods: {
     onClickAddButton(): void {
-      this.handler()
+      this.toggleScreen()
     },
     onCollapseEditingScreen(): void {
-      this.handler()
-      this.closeToReset()
+      this.toggleScreen()
+      this.resetEditingScreen()
     },
-    handler(): void {
+    toggleScreen(): void {
       this.isExpandedButton = !this.isExpandedButton
     },
-    closeToReset(): void {
+    resetEditingScreen(): void {
       this.editPageValue = {
         isHidden: false,
         lessonId: '',
@@ -182,7 +182,7 @@ export default Vue.extend({
           materialsUrl: materialUrl
         }
       }
-      this.handler()
+      this.toggleScreen()
     }
   }
 })

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -34,7 +34,6 @@
     <editing-screen
       :value="editPageValue"
       :expanded="!isExpandedButton"
-      @update:expanded="isExpandedButton = $event"
       @collapse="closeToReset"
     />
   </div>

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -29,7 +29,7 @@
     <simple-bottom-sheet
       message="2年B組の授業を追加・編集する"
       :expanded="isExpandedButton"
-      @addButtonClicked="handler"
+      @clickAddButton="handler"
     />
     <editing-screen
       :value="editPageValue"

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -29,7 +29,7 @@
     <simple-bottom-sheet
       message="2年B組の授業を追加・編集する"
       :expanded="!editingMode"
-      @clickAddButton="onClickAddButton"
+      @clickAddButton="toggleScreen"
     />
     <editing-screen
       :value="editPageValue"
@@ -103,9 +103,6 @@ export default Vue.extend({
     }
   },
   methods: {
-    onClickAddButton(): void {
-      this.toggleScreen()
-    },
     onCollapseEditingScreen(): void {
       this.toggleScreen()
       this.resetEditingScreen()

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -29,12 +29,12 @@
     <simple-bottom-sheet
       message="2年B組の授業を追加・編集する"
       :expanded="isExpandedButton"
-      @clickAddButton="handler"
+      @clickAddButton="onClickAddButton"
     />
     <editing-screen
       :value="editPageValue"
       :expanded="!isExpandedButton"
-      @collapse="closeToReset"
+      @collapse="onCollapseEditingScreen"
     />
   </div>
 </template>
@@ -103,11 +103,17 @@ export default Vue.extend({
     }
   },
   methods: {
+    onClickAddButton(): void {
+      this.handler()
+    },
+    onCollapseEditingScreen(): void {
+      this.handler()
+      this.closeToReset()
+    },
     handler(): void {
       this.isExpandedButton = !this.isExpandedButton
     },
     closeToReset(): void {
-      this.handler()
       this.editPageValue = {
         isHidden: false,
         lessonId: '',


### PR DESCRIPTION
close #145 

- ただ `$emit` するだけの method は除去し、 `$emit` をインラインで記述
- watch はなるべく使わない
    - watch は親・子のどちらかが変更したか曖昧になるため避ける。
    - 子が state を変更しないで済む場合は、単に props として渡す（仕組みとして子が変更できないことが担保される）
    - 子が state を変更しなければならない場合、子は input イベントを値付きで emit して、親に変更してもらう
    - 親の親 ― 親 ― 子 というように親がただの仲介役の場合、上記のような props down, events up の仕組みを応用することで、仲介役たる親が data プロパティを保持しなくて済む
- CalendarBar は 内部Implクラスから CalendarBar の input イベントを直接 emit させる
    - 内部的に持つ currentDate とは別に、任意のタイミング・値に変更できる
- その他、名前の整理