### PR TITLE
詳細説明部分で英文字テキストが折り返すように修正

### DIFF
--- a/src/components/ContentCard.vue
+++ b/src/components/ContentCard.vue
@@ -115,6 +115,7 @@ export default Vue.extend({
     font-size: 12px;
     color: $color-gray;
     margin: 0;
+    word-break: break-all;
   }
 }
 </style>

--- a/src/pages/lesson/index.vue
+++ b/src/pages/lesson/index.vue
@@ -314,6 +314,7 @@ export default Vue.extend({
   font-family: 'Noto Sans JP', sans-serif;
   font-size: 16px;
   color: $color-gray;
+  word-break: break-all;
 }
 
 .lesson-material {


### PR DESCRIPTION
close #221 

**以下の不具合は持ち越しです。**
- フォーム入力時の改行が表示に反映しない→ cssでなんとかなる？
- 「学習の目的」を入力しているにも関わらず、lesson画面に表示されない→ #218 

![スクリーンショット 2020-06-27 15 54 27](https://user-images.githubusercontent.com/14883063/85916883-d1ec9b80-b88f-11ea-9388-fba4375e0f94.png)

![スクリーンショット 2020-06-27 15 53 56](https://user-images.githubusercontent.com/14883063/85916888-dc0e9a00-b88f-11ea-9079-85a504bb018c.png)

![スクリーンショット 2020-06-27 15 53 44](https://user-images.githubusercontent.com/14883063/85916890-e335a800-b88f-11ea-97a3-76d3ccb1e2a6.png)
