### PR TITLE
編集画面の日時のinputのformatを修正

### DIFF
--- a/src/components/EditingScreen1.vue
+++ b/src/components/EditingScreen1.vue
@@ -110,7 +110,7 @@
       v-model="tempFormData.date"
       title="日付設定 *"
       label="date"
-      placeholder="2020/05/30"
+      placeholder="2020-05-30"
       :transparent="true"
       icon-name="mdi-calendar"
       :readonly="true"

--- a/src/pages/edit/index.vue
+++ b/src/pages/edit/index.vue
@@ -250,15 +250,9 @@ export default Vue.extend({
         isHidden: value.isHidden,
         lessonId: value.docId,
         firstPageData: {
-          date:
-            value.startTime.getFullYear() +
-            '-' +
-            (value.startTime.getMonth() + 1) +
-            '-' +
-            value.startTime.getDate(),
-          startTime:
-            value.startTime.getHours() + ':' + value.startTime.getMinutes(),
-          endTime: value.endTime.getHours() + ':' + value.endTime.getMinutes(),
+          date: dayjs(value.startTime).format('YYYY-MM-DD'),
+          startTime: dayjs(value.startTime).format('HH:mm'),
+          endTime: dayjs(value.endTime).format('HH:mm'),
           title: value.title,
           subjectName: value.subject.name,
           subjectColor: value.subject.color


### PR DESCRIPTION
close #222 

とりあえず、日付を `YYYY-MM-DD` 、時刻を `HH:mm` のフォーマットにしました。
editのpageのほうでformatしましたが、場所によって変える場合は `src/components/EditingScreen1.vue` のほうでもformatしたほうがいいかもしれません（今回は保留）。

![スクリーンショット 2020-06-27 23 47 07](https://user-images.githubusercontent.com/14883063/85924957-8dcdbb00-b8d0-11ea-875a-117e8e151cee.png)

