### PR TITLE
ログインするクラスが無いときは「選択クラスでログインする」ボタンを表示しない

### DIFF
--- a/src/pages/user/classlist.vue
+++ b/src/pages/user/classlist.vue
@@ -24,6 +24,7 @@
     </template>
     <template v-slot:LayerFooter>
       <action-button
+        v-if="items && items.length > 0"
         theme="primary"
         text="選択クラスでログインする"
         class="ClassList-Button"


### PR DESCRIPTION
2．表示しない形での修正。(#224)

2パターン、PR出しているので、どちらか一つをマージお願いします。
![スクリーンショット 2020-06-28 6 58 41](https://user-images.githubusercontent.com/19769416/85933105-2cc4d800-b90e-11ea-8c56-aeb6526d4bbc.png)
