### PR TITLE
v-snackbarからabsoluteのpropsを削除

### DIFF
--- a/src/components/EditLessonScreen.vue
+++ b/src/components/EditLessonScreen.vue
@@ -44,7 +44,7 @@
         </v-container>
       </v-card-actions>
     </v-card>
-    <v-snackbar v-model="error" :timeout="5000" absolute top color="#C01B61">
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{ $t('components.editing_screen.error.could_not_add_lesson') }}
     </v-snackbar>
   </v-bottom-sheet>

--- a/src/components/EditingVisibilityDialog.vue
+++ b/src/components/EditingVisibilityDialog.vue
@@ -40,14 +40,14 @@
         </div>
       </template>
     </base-dialog>
-    <v-snackbar v-model="error" :timeout="5000" absolute top color="#C01B61">
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{
         $t(
           'components.editing_visibility_dialog.error.could_not_change_visibility'
         )
       }}
     </v-snackbar>
-    <v-snackbar v-model="success" :timeout="5000" absolute top color="success">
+    <v-snackbar v-model="success" :timeout="5000" top color="success">
       {{ $t('components.editing_visibility_dialog.success.message') }}
     </v-snackbar>
   </div>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -83,7 +83,7 @@
         </div>
       </v-flex>
     </v-flex>
-    <v-snackbar v-model="error" :timeout="5000" absolute top color="#C01B61">
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{ $t('pages.index.error.invalid_class_id') }}
     </v-snackbar>
   </v-layout>

--- a/src/pages/user/editUserData.vue
+++ b/src/pages/user/editUserData.vue
@@ -88,7 +88,7 @@
         </v-btn>
       </template>
     </base-bottom-sheet-layer>
-    <v-snackbar v-model="error" :timeout="5000" absolute top color="#C01B61">
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{ $t('common.general.error.default') }}
     </v-snackbar>
   </div>

--- a/src/pages/user/login.vue
+++ b/src/pages/user/login.vue
@@ -55,7 +55,7 @@
         </div>
       </template>
     </base-bottom-sheet-layer>
-    <v-snackbar v-model="error" :timeout="5000" absolute top color="#C01B61">
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{ $t('pages.user_login.error.invalid') }}
     </v-snackbar>
   </div>
@@ -95,7 +95,7 @@ export default Vue.extend({
       try {
         await Auth.signIn(this.email, this.password)
         // await vxm.user.login()
-        this.$router.push('/user/classlist')
+        await this.$router.push('/user/classlist')
       } catch (err) {
         this.loading = false
         this.error = true

--- a/src/pages/user/logout.vue
+++ b/src/pages/user/logout.vue
@@ -5,7 +5,7 @@
       :title="$t('pages.user_logout.title')"
       title-en="LOGOUT"
     />
-    <v-snackbar v-model="error" :timeout="5000" absolute top color="#C01B61">
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{ $t('pages.user_logout.error.invalid') }}
     </v-snackbar>
   </div>

--- a/src/pages/user/registerClass.vue
+++ b/src/pages/user/registerClass.vue
@@ -43,7 +43,7 @@
         />
       </template>
     </base-bottom-sheet-layer>
-    <v-snackbar v-model="error" :timeout="5000" absolute color="#C01B61" top>
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{ $t('pages.user_register_class.error.default') }}
     </v-snackbar>
   </div>

--- a/src/pages/user/signup.vue
+++ b/src/pages/user/signup.vue
@@ -77,7 +77,7 @@
         </div>
       </template>
     </base-bottom-sheet-layer>
-    <v-snackbar v-model="error" :timeout="5000" absolute top color="#C01B61">
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{ $t('common.general.error.default') }}
     </v-snackbar>
     <v-dialog v-model="completion" max-width="460px">

--- a/src/pages/user/verify.vue
+++ b/src/pages/user/verify.vue
@@ -55,7 +55,7 @@
         </div>
       </template>
     </base-bottom-sheet-layer>
-    <v-snackbar v-model="error" :timeout="5000" absolute top color="#C01B61">
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
       {{ $t('pages.user_verify.error.invalid') }}
     </v-snackbar>
   </div>


### PR DESCRIPTION
v-snackbarのz-indexの関係で、`absolute` 属性は要らなくなったようです（おそらくVuetifyのマイナーアップデートが原因）。