### PR TITLE
サイトトップでログイン状態を取得しボタンを変更

### DIFF
--- a/src/assets/locales/ja.json
+++ b/src/assets/locales/ja.json
@@ -126,7 +126,9 @@
         "label": "時間割をつくる先生方",
         "buttons": {
           "signup": "ユーザー登録する",
-          "login": "ログインする"
+          "login": "ログインする",
+          "registerLessons": "時間割をつくる",
+          "logout": "ログアウトする"
         }
       }
     },

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -39,17 +39,33 @@
         </v-row>
         <div style="margin: 0 10px">
           <base-action-button
+            v-if="isLoggedIn"
+            :text="$t('pages.index.teachers.buttons.registerLessons')"
+            class="registerButton"
+            @click="$router.push('/user/classlist')"
+          />
+          <base-action-button
+            v-else
             :text="$t('pages.index.teachers.buttons.signup')"
             class="registerButton"
             @click="$router.push('/user/terms')"
           />
 
           <base-action-button
+            v-if="isLoggedIn"
+            :text="$t('pages.index.teachers.buttons.logout')"
+            class="loginButton"
+            theme="secondary"
+            @click="$router.push('/user/logout')"
+          />
+          <base-action-button
+            v-else
             :text="$t('pages.index.teachers.buttons.login')"
             class="loginButton"
             theme="secondary"
             @click="$router.push('/user/login')"
           />
+
           <v-footer color="#004170" padless>
             <ul class="Index-Footer-List">
               <li>
@@ -93,7 +109,7 @@
 import Vue from 'vue'
 import BaseInputField from '@/components/BaseInputField.vue'
 import BaseActionButton from '@/components/BaseActionButton.vue'
-import { API } from 'aws-amplify'
+import { API, Auth } from 'aws-amplify'
 import { GRAPHQL_AUTH_MODE, GraphQLResult } from '@aws-amplify/api'
 import { getClass } from '@/graphql/queries'
 import { GetClassQuery } from '@/API'
@@ -104,6 +120,7 @@ type DataType = {
   loading: boolean
   error: boolean
   valid: boolean
+  isLoggedIn: boolean
 }
 
 export default Vue.extend({
@@ -117,7 +134,12 @@ export default Vue.extend({
       loading: false,
       error: false,
       valid: true,
+      isLoggedIn: false,
     }
+  },
+  async mounted() {
+    const userInfo = await Auth.currentUserInfo()
+    this.isLoggedIn = !!userInfo
   },
   methods: {
     async loginToClass() {


### PR DESCRIPTION
#371 の対応です（aws-migrationブランチで実装しています）。
ログイン済みだった場合、サイトトップのボタン「時間割をつくる」→クラス選択画面に遷移、「ログアウトする」→ログアウト画面に遷移します。
各サブページでの挙動は自信がないのですが、少なくとも時間割カレンダー表示画面でリロードした場合にサイトトップに遷移して、ログイン済み状態の表示になります。

![スクリーンショット 2020-09-24 15 40 08](https://user-images.githubusercontent.com/14883063/94109633-3f529d00-fe7c-11ea-85b3-57a498197c7e.png)
