### PR TITLE
 isLoginWithAPIKEYをstoreから削除

### DIFF
--- a/src/pages/classes/index.vue
+++ b/src/pages/classes/index.vue
@@ -59,11 +59,11 @@ export default Vue.extend({
   },
   watch: {
     async currentDate() {
-      await this.classData.getLessonsByCurrentDate()
+      await this.classData.getLessonsByCurrentDateAuthModeAPIKEY()
     },
   },
   async mounted() {
-    await this.classData.getLessonsByCurrentDate()
+    await this.classData.getLessonsByCurrentDateAuthModeAPIKEY()
   },
 })
 </script>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -145,7 +145,6 @@ export default Vue.extend({
     async loginToClass() {
       this.loading = true
       try {
-        await vxm.user.setAuthModeIsAPIKEY(true)
         const result = (await API.graphql({
           query: getClass,
           variables: { id: this.classId },

--- a/src/pages/lesson/index.vue
+++ b/src/pages/lesson/index.vue
@@ -238,11 +238,9 @@ export default Vue.extend({
     },
   },
   async mounted() {
-    const lessonList = vxm.user.isLoginWithAPIKEY
-      ? await vxm.classData.lessonsOnCurrentDateAuthModeAPIKEY(
-          vxm.app.currentDate
-        )
-      : await vxm.classData.lessonsOnCurrentDate(vxm.app.currentDate)
+    const lessonList = await vxm.classData.lessonsOnCurrentDateAuthModeAPIKEY(
+      vxm.app.currentDate
+    )
     await this.$nextTick(function () {
       const data: LessonWithId | undefined = lessonList.find(
         (e) => this.$route.query.lessonId === e.id

--- a/src/pages/user/editUserData.vue
+++ b/src/pages/user/editUserData.vue
@@ -125,6 +125,7 @@ type Computed = {
 export default Vue.extend<Data, Methods, Computed, unknown>({
   components: { BaseBottomSheetLayer, BaseActionButton, BaseInputField },
   layout: 'background',
+  middleware: 'authenticated',
   data() {
     return {
       name: vxm.user.displayName,

--- a/src/store/modules/classData.ts
+++ b/src/store/modules/classData.ts
@@ -5,7 +5,6 @@ import {
   mutation,
 } from 'vuex-class-component'
 import { AppStore } from '@/store/modules/app'
-import { UserStore } from '@/store/modules/user'
 import classData from '@/types/store/classData'
 import { API, Auth, graphqlOperation } from 'aws-amplify'
 import { GRAPHQL_AUTH_MODE, GraphQLResult } from '@aws-amplify/api'
@@ -227,10 +226,16 @@ export class ClassDataStore extends VuexModule implements classData.ClassData {
   @action
   public async getLessonsByCurrentDate() {
     const appStore = createProxy(this.$store, AppStore)
-    const userStore = createProxy(this.$store, UserStore)
-    const lessons = userStore.isLoginWithAPIKEY
-      ? await this.lessonsOnCurrentDateAuthModeAPIKEY(appStore.currentDate)
-      : await this.lessonsOnCurrentDate(appStore.currentDate)
+    const lessons = await this.lessonsOnCurrentDate(appStore.currentDate)
+    await this.setLessonsGroupByPeriod(lessons)
+  }
+
+  @action
+  public async getLessonsByCurrentDateAuthModeAPIKEY() {
+    const appStore = createProxy(this.$store, AppStore)
+    const lessons = await this.lessonsOnCurrentDateAuthModeAPIKEY(
+      appStore.currentDate
+    )
     await this.setLessonsGroupByPeriod(lessons)
   }
 

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -35,7 +35,6 @@ export class UserStore extends VuexModule implements User {
   emailVerified: EmailVerified = false
   displayName: DisplayName = ''
   uid: Uid = ''
-  isLoginWithAPIKEY: LoginWithAPIKEY = false
 
   public get isAuthenticated(): Promise<boolean> {
     return (async () => {
@@ -51,11 +50,6 @@ export class UserStore extends VuexModule implements User {
     this.emailVerified = emailVerified
     this.displayName = displayName
     this.uid = uid
-  }
-
-  @mutation
-  public setAuthModeIsAPIKEY(isLoginWithAPIKEY: LoginWithAPIKEY) {
-    this.isLoginWithAPIKEY = isLoginWithAPIKEY
   }
 
   @action
@@ -88,6 +82,5 @@ export class UserStore extends VuexModule implements User {
       emailVerified: false,
       displayName: '',
     })
-    this.isLoginWithAPIKEY = false
   }
 }


### PR DESCRIPTION
- authMode判定（isLoginWithAPIKEY）をstoreに持たせるのをやめました。
- ユーザー情報の変更ページ（/user/editUserData）に `middleware: 'authenticated'` を追加しました。