### PR TITLE
ユーザー情報変更ページをAmplifyに対応

### DIFF
--- a/src/assets/locales/ja.json
+++ b/src/assets/locales/ja.json
@@ -149,6 +149,7 @@
     "user_edit_user_data": {
       "title": "ユーザー情報の変更",
       "labels": {
+        "old_password": "現在のパスワード",
         "new_password": "変更先パスワード",
         "new_password_confirm": "変更先パスワード（確認用）"
       }
@@ -194,6 +195,12 @@
         "go_back_to_top": "トップに戻る",
         "message": "入力いただいたメールアドレス宛に確認メールを送信しました。メールに記載されているURLから認証を行ってください。"
       }
+    },
+    "user_verify": {
+      "title": "メールアドレス確認"
+    },
+    "user_verify_new_email": {
+      "title": "メールアドレス変更確認"
     }
   }
 }

--- a/src/pages/user/verify.vue
+++ b/src/pages/user/verify.vue
@@ -3,7 +3,7 @@
     <base-bottom-sheet-layer
       fullscreen
       :title="$t('pages.user_verify.title')"
-      title-en="LOGIN"
+      title-en="VERIFY EMAIL"
     >
       <template v-slot:LayerContents>
         <dl>

--- a/src/pages/user/verifyNewEmail.vue
+++ b/src/pages/user/verifyNewEmail.vue
@@ -1,0 +1,127 @@
+<template>
+  <div>
+    <base-bottom-sheet-layer
+      fullscreen
+      :title="$t('pages.user_verify_new_email.title')"
+      title-en="VERIFY NEW EMAIL"
+    >
+      <template v-slot:LayerContents>
+        <dl>
+          <dt class="SignIn-ItemTitle">
+            {{ $t('common.user_data.labels.email') }}
+          </dt>
+          <dd class="SignIn-Item">
+            <base-input-field
+              v-model="email"
+              label="studyathome@example.com"
+              require
+              type="email"
+            />
+          </dd>
+          <dt class="SignIn-ItemTitle">
+            {{ $t('common.user_data.labels.verification_code') }}
+          </dt>
+          <dd class="SignIn-Item">
+            <base-input-field
+              v-model="verification_code"
+              :label="$t('common.user_data.labels.verification_code')"
+              require
+              type="number"
+            />
+          </dd>
+        </dl>
+      </template>
+      <template v-slot:LayerFooter>
+        <div class="SignIn-ButtonOuter">
+          <base-action-button
+            :is-disabled="disableLogin"
+            :is-loading="loading"
+            class="SignIn-Button"
+            :text="$t('common.general.buttons.verify')"
+            theme="primary"
+            @click="doVerify"
+          />
+          <v-btn
+            :disabled="loading"
+            block
+            class="button"
+            color="#ffffff"
+            height="60px"
+            text
+            to="/"
+          >
+            <span>{{ $t('common.general.buttons.go_back') }}</span>
+          </v-btn>
+        </div>
+      </template>
+    </base-bottom-sheet-layer>
+    <v-snackbar v-model="error" :timeout="5000" top color="#C01B61">
+      {{ $t('pages.user_verify.error.invalid') }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import BaseBottomSheetLayer from '@/components/BaseBottomSheetLayer.vue'
+import BaseActionButton from '@/components/BaseActionButton.vue'
+import BaseInputField from '@/components/BaseInputField.vue'
+import { Auth } from 'aws-amplify'
+
+export default Vue.extend({
+  components: { BaseBottomSheetLayer, BaseActionButton, BaseInputField },
+  layout: 'background',
+  data() {
+    return {
+      email: '',
+      verification_code: '',
+      loading: false,
+      error: false,
+    }
+  },
+  computed: {
+    disableVerify(): boolean {
+      return !(
+        this.email &&
+        this.verification_code &&
+        this.email.match(/^\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*$/)
+      )
+    },
+  },
+  methods: {
+    async doVerify(): Promise<void> {
+      this.loading = true
+      await Auth.verifyCurrentUserAttributeSubmit(
+        'email',
+        this.verification_code
+      )
+        .then(() => {
+          this.$router.push('/user/classlist')
+        })
+        .catch(() => {
+          this.loading = false
+          this.error = true
+        })
+    },
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.SignIn-ItemTitle {
+  font-size: 16px;
+  font-weight: bold;
+  color: $color-white;
+  text-align: center;
+  margin: 4px 0;
+}
+.SignIn-Item {
+  margin: 20px 0;
+}
+.SignIn-ButtonOuter {
+  justify-content: space-between;
+}
+.SignIn-Button {
+  flex: 0 1 48%;
+}
+</style>

--- a/src/pages/user/verifyNewEmail.vue
+++ b/src/pages/user/verifyNewEmail.vue
@@ -71,6 +71,7 @@ import { Auth } from 'aws-amplify'
 export default Vue.extend({
   components: { BaseBottomSheetLayer, BaseActionButton, BaseInputField },
   layout: 'background',
+  middleware: 'authenticated',
   data() {
     return {
       email: '',


### PR DESCRIPTION
このPRでは、nameとemailとpasswordを別々に変更かけたときにしか対応していないので、複数の項目を同時に変更するようにするには検討が必要です。