### PR TITLE
lesson検索時のDate形式にmillisecondsを追加

### DIFF
--- a/src/store/modules/classData.ts
+++ b/src/store/modules/classData.ts
@@ -95,17 +95,24 @@ const generateUniqueId = (): string => {
   return result + ''
 }
 // Generate a new Date object with a specified date & time
-const d = (date: Date, hours: number, minutes: number, seconds: number) => {
+const d = (
+  date: Date,
+  hours: number,
+  minutes: number,
+  seconds: number,
+  milliseconds: number
+) => {
   const newDate = new Date(date)
   newDate.setHours(hours)
   newDate.setMinutes(minutes)
   newDate.setSeconds(seconds)
+  newDate.setMilliseconds(milliseconds)
   return newDate
 }
 
 const getFullDayArray = (date: Date) => {
-  const start = d(date, 0, 0, 0)
-  const end = d(date, 24, 0, 0)
+  const start = d(date, 0, 0, 0, 0)
+  const end = d(date, 24, 0, 0, 0)
   return [start, end]
 }
 


### PR DESCRIPTION
close #457 

lesson検索時のDate形式にミリ秒を追加、常に000を返すように修正しました。

<img width="627" alt="スクリーンショット 2020-10-14 18 33 20" src="https://user-images.githubusercontent.com/14883063/95971649-7220fd00-0e4c-11eb-9d6a-bdd5f66b8cb0.png">

<img width="564" alt="スクリーンショット 2020-10-14 18 33 41" src="https://user-images.githubusercontent.com/14883063/95971669-7a793800-0e4c-11eb-8d0e-075f3fc2005a.png">


