### PR TITLE
package.jsonのdevDependenciesからwebpackをremove

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "vue-class-component": "7.2.6",
     "vue-jest": "3.0.7",
     "vue-server-renderer": "2.6.14",
-    "vue-template-compiler": "2.6.14",
-    "webpack": "4.46.0"
+    "vue-template-compiler": "2.6.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14773,7 +14773,7 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.46.0, webpack@^4.46.0:
+webpack@^4.46.0:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==


### PR DESCRIPTION
nuxtにwebpackは含まれているので、単独でのwebpackは不要。